### PR TITLE
Pmenu: differentiate between selected and not.

### DIFF
--- a/colors/adio.vim
+++ b/colors/adio.vim
@@ -106,7 +106,7 @@ if &t_Co > 255
   "hl-Pmenu           Popup menu: normal item.
   hi Pmenu            ctermfg=none ctermbg=none cterm=none
   "hl-PmenuSel        Popup menu: selected item.
-  hi PmenuSel         ctermfg=none ctermbg=none cterm=none
+  hi PmenuSel         ctermfg=248 ctermbg=235 cterm=none
   "hl-PmenuSbar       Popup menu: scrollbar.
   hi PmenuSbar        ctermfg=none ctermbg=none cterm=none
   "hl-PmenuThumb      Popup menu: Thumb of the scrollbar.


### PR DESCRIPTION
The current Pmenu colors do not differentiate between the selected item
and the rest of the list.  This is extremely confusing for users using
completion backends.
